### PR TITLE
Camera2: Fix Undo button behaviour

### DIFF
--- a/src/com/android/camera/CameraActivity.java
+++ b/src/com/android/camera/CameraActivity.java
@@ -1335,7 +1335,8 @@ public class CameraActivity extends QuickActivity
 
     private void removeItemAt(int index) {
         mDataAdapter.removeAt(index);
-        if (mDataAdapter.getTotalNumber() > 1) {
+        final int placeholders = mSecureCamera ? 1 : 0;
+        if (mDataAdapter.getTotalNumber() > placeholders) {
             showUndoDeletionBar();
         } else {
             // If camera preview is the only view left in filmstrip,


### PR DESCRIPTION
The undo behaviour depends on if the camera present secure settings
or not. If secure, it should have 1 placeholder. 0 in other cases.

Repro (for non secure cameras):
1. Leave only 3 pictures on the album.
2. Delete one picture, it will work fine.
3. Leave only 2 pictures on the album.
4. Try to delete, and you will go straight to the camera,
without the undo pannel showing up.

Change-Id: I360076381867a74628ffa492065ccf2ca53c72d6